### PR TITLE
fix(dropdowns): Close dropdowns automatically on clicks outside the dropdown

### DIFF
--- a/assets/js/component/dropdown.js
+++ b/assets/js/component/dropdown.js
@@ -1,6 +1,17 @@
 let dropdowns = document.querySelectorAll('.dropdown')
+const openSelector = '.dropdown-menu.show';
+
 dropdowns.forEach(el => {
     el.addEventListener('click', function () {
+        document.querySelectorAll(openSelector).forEach(openDropdownEl => openDropdownEl.classList.remove('show'));
         el.querySelector('.dropdown-menu').classList.toggle('show');
     })
+});
+
+document.body.addEventListener('click', function (e) {
+    let offsetParent = e.target.offsetParent;
+    let isDropdownMenu = (offsetParent) ? offsetParent.classList.contains("dropdown") : false;
+
+    if (!isDropdownMenu)
+        document.querySelectorAll(openSelector).forEach(el => el.classList.remove('show'));
 });

--- a/assets/js/component/dropdown.js
+++ b/assets/js/component/dropdown.js
@@ -2,15 +2,19 @@ let dropdowns = document.querySelectorAll('.dropdown')
 const openSelector = '.dropdown-menu.show';
 
 dropdowns.forEach(el => {
-    el.addEventListener('click', function () {
+    el.addEventListener('click', function (e) {
+        let alreadyShown = el.querySelector('.dropdown-menu.show');
+
         document.querySelectorAll(openSelector).forEach(openDropdownEl => openDropdownEl.classList.remove('show'));
-        el.querySelector('.dropdown-menu').classList.toggle('show');
+
+        if (!alreadyShown)
+            el.querySelector('.dropdown-menu').classList.toggle('show');
     })
 });
 
 document.body.addEventListener('click', function (e) {
     let offsetParent = e.target.offsetParent;
-    let isDropdownMenu = (offsetParent) ? offsetParent.classList.contains("dropdown") : false;
+    let isDropdownMenu = (offsetParent) ? offsetParent.classList.contains('dropdown') : false;
 
     if (!isDropdownMenu)
         document.querySelectorAll(openSelector).forEach(el => el.classList.remove('show'));


### PR DESCRIPTION
Related issue: #3 

Dropdowns now close when the user clicks:
- [x] on the dropdown menu button
- [x] on a dropdown menu item
- [x] outside the dropdown

Additionally, when clicking on a dropdown while another dropdown is open, the dropdowns behave as expected:
1. Previously open dropdown closes
2. Clicked dropdown opens

Tested on:
- Windows 11 Firefox
- iOS 16.5.1 Safari