### PR TITLE
fix(dropdowns): Adds highlight colors to dropdown menu in dark/night modes

### DIFF
--- a/assets/scss/component/_dropdown.scss
+++ b/assets/scss/component/_dropdown.scss
@@ -48,6 +48,14 @@
   background: rgba(0, 0, 0, 0.05);
 }
 
+:root[data-color="dark"] .dropdown-menu button:hover, .dropdown-menu a:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+:root[data-color="night"] .dropdown-menu button:hover, .dropdown-menu a:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
 :root[data-color="dark"] .dropdown-menu{
   background: #121212;
 }


### PR DESCRIPTION
Light mode darkens the menu item background for `:hover`, but that is invisible in dark/night modes.

This PR changes it so that in dark/night modes, `:hover` instead lightens the menu item background.

I didn't make an issue for this, but let me know if you'd like one for tracking and I'll happily make it. :)

Tested on:
- Windows 11 Firefox
- iOS 16.5.1 Safari
