### PR TITLE
nitpick(dropdowns): Move dropdown menu away from button, add arrow

### DIFF
--- a/assets/js/component/dropdown.js
+++ b/assets/js/component/dropdown.js
@@ -6,9 +6,12 @@ dropdowns.forEach(el => {
         let alreadyShown = el.querySelector('.dropdown-menu.show');
 
         document.querySelectorAll(openSelector).forEach(openDropdownEl => openDropdownEl.classList.remove('show'));
+        document.querySelectorAll('.dropdown-btn').forEach(dropdownButtonEl => dropdownButtonEl.classList.remove('arrow'));
 
-        if (!alreadyShown)
+        if (!alreadyShown){
             el.querySelector('.dropdown-menu').classList.toggle('show');
+            el.querySelector('.dropdown-btn').classList.toggle('arrow');
+        }
     })
 });
 
@@ -16,6 +19,8 @@ document.body.addEventListener('click', function (e) {
     let offsetParent = e.target.offsetParent;
     let isDropdownMenu = (offsetParent) ? offsetParent.classList.contains('dropdown') : false;
 
-    if (!isDropdownMenu)
+    if (!isDropdownMenu){
         document.querySelectorAll(openSelector).forEach(el => el.classList.remove('show'));
+        document.querySelectorAll('.dropdown-btn').forEach(dropdownButtonEl => dropdownButtonEl.classList.remove('arrow'));
+    }
 });

--- a/assets/scss/component/_dropdown.scss
+++ b/assets/scss/component/_dropdown.scss
@@ -1,5 +1,5 @@
 .dropdown {
-  position: relative;
+    position: relative;
 }
 
 .dropdown-btn {
@@ -19,18 +19,19 @@
 .dropdown-menu {
   display: none;
   position: absolute;
+  z-index: 3;
+  top: 42px;
   right: 0;
   min-width: 100px;
   max-height: 240px;
   overflow-x: auto;
   border: 1px solid var(--border-color);
   background: white;
-  z-index: 1;
   border-radius: 6px;
   padding: 3px;
 }
 
-.dropdown-menu.show {
+.dropdown-menu.show{
   display: block;
 }
 
@@ -39,9 +40,22 @@
   display: flex;
   gap: 2px;
   padding: 6px;
-  align-items: center;
-  justify-content: center;
+  align-items: left;
+  justify-content: left;
   cursor: pointer;
+}
+
+.dropdown-btn.arrow:after {
+    content: '';
+    position: absolute;
+    z-index: 2;
+    right: 10px;
+    top: 35px;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 9px solid var(--border-color);
 }
 
 .dropdown-menu button:hover, .dropdown-menu a:hover {


### PR DESCRIPTION
Discussed here: https://github.com/docura/docura/pull/4#issuecomment-1666388399

- Separates menu from button
- Adds arrow at top of menu to point to button
- Left-aligns menu items for readability and consistence

Making the PR to contain discussion on this in a useful place, no need to merge if you're not comfortable with it of course! Let me know if you have any feedback on this one.