### PR TITLE
Enable use as a hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,3 @@ A modular Hugo theme to build your next documentation site
     echo "theme = 'docura'" >> config/_default/config.toml
     hugo server
     ```
-
-### Via Module
-
-You can also add this theme as a Hugo module instead of a git submodule.
-Navigate to your hugo project root and edit your `config.toml`:
-
-```toml
-[module]
-[[module.imports]]
-path = 'github.com/docura/docura'
-```
-
-Then, to load/update the theme module, run:
-
-```shell
-hugo mod get -u
-```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,20 @@ A modular Hugo theme to build your next documentation site
     echo "theme = 'docura'" >> config/_default/config.toml
     hugo server
     ```
+
+### Via Module
+
+You can also add this theme as a Hugo module instead of a git submodule.
+Navigate to your hugo project root and edit your `config.toml`:
+
+```toml
+[module]
+[[module.imports]]
+path = 'github.com/docura/docura'
+```
+
+Then, to load/update the theme module, run:
+
+```shell
+hugo mod get -u
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/docura/docura
+
+go 1.20


### PR DESCRIPTION
This commit does the minimal work to make the Docura theme a functional hugo module by adding the go.mod file and including instructions in the project README for use.

This is based on [michaeltlombardi](https://github.com/michaeltlombardi)'s work on https://github.com/alex-shpak/hugo-book/pull/376