### PR TITLE
Fix sidebar conditional for multi language detection

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -3,18 +3,21 @@
 {{- $url := split .Permalink "/" -}}
 {{- $urlPageSlug := index $url (sub (len $url) 2) -}}
 
+{{ $currentLang := .Site.Language.Lang }}
+{{ $defaultLang := .Sites.First.Language.Lang }}
+
 <aside id="sidebar">
   <span class="btn-close"><i class="icon icon-close"></i></span>
 
   <div class="sticky">
-    {{- range $group := $data -}}
+	{{- range $group := $data -}}
       <strong class="sidebar-section">{{ $group.title }}</strong>
 
       {{- range $index, $page := $group.pages -}}
         {{- $pageSlug := $page.title | urlize -}}
         {{- $isActivePage := eq $urlPageSlug $pageSlug -}}
 
-        {{ if eq .Site.Language.Lang .Site.DefaultContentLanguage }}
+        {{ if eq $currentLang $defaultLang }}
           {{ $href := printf "/%s/%s/" $.Section $pageSlug }}
           <a class="sidebar-link {{ if $isActivePage }}current{{ end }}" href="{{ $href }}">
             {{ if and (eq $index 0) $group.replaceFirstPageTitle }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -28,7 +28,7 @@
           </a>
 
         {{ else }}
-          {{ $href := printf "/%s/%s/%s/" $.Site.Language.Lang $.Section $pageSlug }}
+          {{ $href := printf "/%s/%s/%s/" $currentLang $.Section $pageSlug }}
           <a class="sidebar-link {{ if $isActivePage }}current{{ end }}" href="{{ $href }}">
             {{ if and (eq $index 0) $group.replaceFirstPageTitle }}
               {{ $group.replaceFirstPageTitle }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,7 +10,7 @@
   <span class="btn-close"><i class="icon icon-close"></i></span>
 
   <div class="sticky">
-	{{- range $group := $data -}}
+    {{- range $group := $data -}}
       <strong class="sidebar-section">{{ $group.title }}</strong>
 
       {{- range $index, $page := $group.pages -}}


### PR DESCRIPTION
I saw two issues with this.
- Firstly: `.Site.DefaultContentLanguage`

    I'm not sure the reason, but I cannot get this to work, even with the parameter correctly set in the toml/yaml config file,
    and confirming with `hugo config`.
    I get the following error: `can’t evaluate field DefaultContentLanguage in type page.Site `
    
    I used `.Sites.First.Language.Lang` instead.

- Secondly: calling the default language from inside the nested range seems to mess with it getting the proper context.
    I defined variables for `Default` and `Current` language at the top, and called those in the conditional and href.
    
 
 First ever pull-request, so let me know if it's adequate.